### PR TITLE
Add bilingual podcast generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## API
+
+### POST `/generate`
+
+Generate a podcast mp3 from an article.
+
+Body parameters:
+
+- `article` (string, required): source text.
+- `language` (string, optional): `'en'` for English (default) or `'zh'` for Simplified Chinese.
+
+The response downloads the resulting `podcast.mp3` file.
+
 ## Support
 
 Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).

--- a/src/generate/dto/generate.dto.ts
+++ b/src/generate/dto/generate.dto.ts
@@ -1,7 +1,11 @@
 // src/generate/dto/generate.dto.ts
-import { IsString } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 
 export class GenerateDto {
     @IsString()
     article: string;
+
+    @IsString()
+    @IsOptional()
+    language?: string;
 }

--- a/src/generate/generate.controller.ts
+++ b/src/generate/generate.controller.ts
@@ -10,7 +10,8 @@ export class GenerateController {
 
     @Post()
     async generatePodcast(@Body() dto: GenerateDto, @Res() res: Response) {
-        const filePath = await this.generateService.generate(dto.article);
+        const lang = dto.language ?? 'en';
+        const filePath = await this.generateService.generate(dto.article, lang);
         res.download(filePath, 'podcast.mp3');
     }
 }

--- a/src/generate/generate.service.ts
+++ b/src/generate/generate.service.ts
@@ -13,8 +13,8 @@ export class GenerateService {
         private readonly ttsService: TtsService,
     ) {}
 
-    async generate(article: string): Promise<string> {
-        const dialogue = await this.llmService.generateDialogue(article);
+    async generate(article: string, language: string): Promise<string> {
+        const dialogue = await this.llmService.generateDialogue(article, language);
         console.log(dialogue);
         const lines = dialogue.split('\n').filter(Boolean);
         const audioPaths: string[] = [];

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -12,8 +12,10 @@ export class LlmService {
         apiKey: process.env.OPENAI_API_KEY,
     });
 
-    async generateDialogue(article: string): Promise<string> {
-        const prompt = `
+    async generateDialogue(article: string, language: string): Promise<string> {
+        let prompt: string;
+        if (language === 'zh') {
+            prompt = `
 文章："""${article}"""
 
 任务：基于上方内容，创作一段有趣又富有信息量的播客风格对话，主持人是 Amy，嘉宾专家是 Evan。两者均为中国大陆居民，因此请考虑适合中国大陆的对话。
@@ -26,6 +28,20 @@ export class LlmService {
 
 要求口吻自然，内容有吸引力。
 `;
+        } else {
+            prompt = `
+Article: """${article}"""
+
+Task: Create a fun and informative podcast-style conversation between [Amy] (host) and [Evan] (expert) discussing the content above.
+
+Format:
+[Amy]: ...
+[Evan]: ...
+[Amy]: ...
+[Evan]: ...
+
+Be engaging and natural.`;
+        }
 
         const res = await this.openai.chat.completions.create({
             model: 'gpt-4',


### PR DESCRIPTION
## Summary
- allow specifying podcast language via request DTO
- adjust GenerateService and LlmService for EN/ZH prompts
- document `/generate` endpoint with optional `language` param

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866386783b48324b38a83635e671560