### PR TITLE
Fix tmp folder usage

### DIFF
--- a/src/generate/generate.service.ts
+++ b/src/generate/generate.service.ts
@@ -17,16 +17,21 @@ export class GenerateService {
         const dialogue = await this.llmService.generateDialogue(article, language);
         console.log(dialogue);
         const lines = dialogue.split('\n').filter(Boolean);
+
+        const baseDir = path.join(__dirname, '../../output');
+        const taskDir = path.join(baseDir, `${Date.now()}`);
+        fs.mkdirSync(taskDir, { recursive: true });
+
         const audioPaths: string[] = [];
 
         for (let i = 0; i < lines.length; i++) {
             const [speaker, content] = lines[i].split(': ');
             const voice = speaker.includes('[Amy]') ? 'voice1' : 'voice2';
-            const audioPath = await this.ttsService.speak(content, voice, i);
+            const audioPath = await this.ttsService.speak(content, voice, i, taskDir);
             audioPaths.push(audioPath);
         }
 
-        const podcastPath = path.join(__dirname, '../../tmp/podcast.mp3');
+        const podcastPath = path.join(taskDir, 'podcast.mp3');
         await concatAudioFiles(audioPaths, podcastPath);
         audioPaths.forEach(p => fs.unlinkSync(p)); // clean up
         return podcastPath;

--- a/src/tts/tts.service.ts
+++ b/src/tts/tts.service.ts
@@ -22,7 +22,7 @@ export class TtsService {
         voice2: 'YOUR_VOICE_ID_2',
     };
 
-    async speak(text: string, voice: 'voice1' | 'voice2', index: number): Promise<string> {
+    async speak(text: string, voice: 'voice1' | 'voice2', index: number, dir: string): Promise<string> {
         console.log(`${voice}: ${text}`);
         const response = await axios.post(
             `https://api.elevenlabs.io/v1/text-to-speech/${this.VOICES[voice]}`,
@@ -40,7 +40,8 @@ export class TtsService {
             },
         );
 
-        const filePath = path.join(__dirname, `../../tmp/part-${index}.mp3`);
+        fs.mkdirSync(dir, { recursive: true });
+        const filePath = path.join(dir, `part-${index}.mp3`);
         fs.writeFileSync(filePath, response.data);
         return filePath;
     }

--- a/src/utils/audio-utils.ts
+++ b/src/utils/audio-utils.ts
@@ -1,13 +1,17 @@
 // src/utils/audio-utils.ts
 import { exec } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
 
 export async function concatAudioFiles(files: string[], outputPath: string): Promise<void> {
-    const listFile = 'tmp/list.txt';
+    const dir = path.dirname(outputPath);
+    const listFile = path.join(dir, 'list.txt');
     const content = files.map(f => `file '${f}'`).join('\n');
-    require('fs').writeFileSync(listFile, content);
+    fs.writeFileSync(listFile, content);
 
     return new Promise((resolve, reject) => {
         exec(`ffmpeg -f concat -safe 0 -i ${listFile} -c copy ${outputPath}`, (error) => {
+            fs.unlinkSync(listFile);
             if (error) reject(error);
             else resolve();
         });


### PR DESCRIPTION
## Summary
- create per-task output directory instead of relying on a global `tmp`
- write intermediate audio and list files to that task directory
- ensure TTS service accepts directory path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68663b6a3c4c8324bf27efe4c2e90b34