### PR TITLE
Fix colon splitting bug

### DIFF
--- a/src/generate/generate.service.ts
+++ b/src/generate/generate.service.ts
@@ -25,7 +25,10 @@ export class GenerateService {
         const audioPaths: string[] = [];
 
         for (let i = 0; i < lines.length; i++) {
-            const [speaker, content] = lines[i].split(': ');
+            const match = lines[i].match(/^(.+?)[:\uff1a]\s*(.*)$/);
+            if (!match) continue;
+            const speaker = match[1];
+            const content = match[2];
             const voice = speaker.includes('[Amy]') ? 'voice1' : 'voice2';
             const audioPath = await this.ttsService.speak(content, voice, i, taskDir);
             audioPaths.push(audioPath);


### PR DESCRIPTION
## Summary
- handle both English and Chinese colons when parsing generated dialogue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866454f2f68832482c2bbb6dcd34431