### PR TITLE
Persist GPT dialogue to output folder

### DIFF
--- a/src/generate/generate.service.ts
+++ b/src/generate/generate.service.ts
@@ -1,5 +1,5 @@
 // src/generate/generate.service.ts
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { LlmService } from '../llm/llm.service';
 import { TtsService } from '../tts/tts.service';
 import { concatAudioFiles } from '../utils/audio-utils';
@@ -12,15 +12,17 @@ export class GenerateService {
         private readonly llmService: LlmService,
         private readonly ttsService: TtsService,
     ) {}
+    private readonly logger = new Logger(GenerateService.name);
 
     async generate(article: string, language: string): Promise<string> {
-        const dialogue = await this.llmService.generateDialogue(article, language);
-        console.log(dialogue);
-        const lines = dialogue.split('\n').filter(Boolean);
-
         const baseDir = path.join(__dirname, '../../output');
         const taskDir = path.join(baseDir, `${Date.now()}`);
         fs.mkdirSync(taskDir, { recursive: true });
+
+        const dialogue = await this.llmService.generateDialogue(article, language);
+        this.logger.log(`Dialogue generated:\n${dialogue}`);
+        fs.writeFileSync(path.join(taskDir, 'dialogue.txt'), dialogue);
+        const lines = dialogue.split('\n').filter(Boolean);
 
         const audioPaths: string[] = [];
 

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -1,5 +1,5 @@
 // src/llm/llm.service.ts
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 
@@ -8,6 +8,7 @@ export class LlmService {
 
     constructor(private configService: ConfigService) {
     }
+    private readonly logger = new Logger(LlmService.name);
     private readonly openai = new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
     });
@@ -47,7 +48,9 @@ Be engaging and natural.`;
             model: 'gpt-4',
             messages: [{ role: 'user', content: prompt }],
         });
+        const content = res.choices[0].message?.content || '';
+        this.logger.log(`OpenAI response: ${content}`);
 
-        return res.choices[0].message?.content || '';
+        return content;
     }
 }


### PR DESCRIPTION
## Summary
- save the GPT-generated dialogue to `output/<timestamp>/dialogue.txt`
- keep logging the generated dialogue using NestJS `Logger`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68665d497b388324853c688a2da8a300